### PR TITLE
Remove debug print statement from decorator

### DIFF
--- a/openai_functools/metadata_generator.py
+++ b/openai_functools/metadata_generator.py
@@ -12,8 +12,6 @@ def openai_function(func: Callable) -> Callable:
     """Wrapper for functions to add .openai_metadata property"""
     func.openai_metadata = extract_openai_function_metadata(func)
 
-    print(get_type_hints(func))
-
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         return func(*args, **kwargs)


### PR DESCRIPTION
This PR removes an orphaned print statement likely left from debugging. The removal doesn't affect functionality but should clean up the output for users.

Local testing confirms the application functions as expected without the debug print.